### PR TITLE
Add R8G8B8A8_UNORM textures for XB1 DE

### DIFF
--- a/XbTool/XbTool/Common/Textures/Decode.cs
+++ b/XbTool/XbTool/Common/Textures/Decode.cs
@@ -57,6 +57,10 @@ namespace XbTool.Common.Textures
                     Swizzle.Deswizzle(texture, 4);
                     decoded = Dxt.DecompressBc7(texture);
                     break;
+                case TextureFormat.R8G8B8A8_UNORM:
+                    Swizzle.Deswizzle(texture, 4, 1);
+                    decoded = texture.Data;
+                    break;
             }
 
             return decoded;

--- a/XbTool/XbTool/Common/Textures/TextureFormat.cs
+++ b/XbTool/XbTool/Common/Textures/TextureFormat.cs
@@ -7,6 +7,7 @@ namespace XbTool.Common.Textures
         BC3 = 0x44,
         BC4 = 0x49,
         BC7 = 0x4D,
-        BC6H_UF16 = 0x50
+        BC6H_UF16 = 0x50,
+        R8G8B8A8_UNORM = 0x25
     }
 }

--- a/XbTool/XbTool/Xb2/Textures/Swizzle.cs
+++ b/XbTool/XbTool/Xb2/Textures/Swizzle.cs
@@ -5,13 +5,13 @@ namespace XbTool.Xb2.Textures
 {
     public static class Swizzle
     {
-        public static void Deswizzle(ITexture texture, int bppPower)
+        public static void Deswizzle(ITexture texture, int bppPower, int swizzleSize = 4)
         {
             int bpp = 1 << bppPower;
 
             int len = texture.Data.Length;
             int originWidth = (texture.Width + 3) / 4;
-            int originHeight = (texture.Height + 3) / 4;
+            int originHeight = (texture.Height + 3) / swizzleSize;
 
             int xb = CountZeros(Pow2RoundUp(originWidth));
             int yb = CountZeros(Pow2RoundUp(originHeight));


### PR DESCRIPTION
Didn't realize this actually made a difference when I tested this at the end of last year. This gets *a lot* more images out of DE's wilay files.

This also adds a small change to the deswizzle function, as R8G8B8A8_UNORM is essentially just swizzled integers, so the swizzle size of this format is 1, compared to everything else's 4.